### PR TITLE
Use .yamllint to avoid shell issues

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,6 @@
+extends: default
+
+rules:
+  line-length:
+    ignore: |
+      src/commands/fleece-run-to-env.yml

--- a/src/commands/fleece-run-to-env.yml
+++ b/src/commands/fleece-run-to-env.yml
@@ -14,5 +14,4 @@ steps:
         fleece run \
         -c << parameters.config >> \
         -e <<parameters.stage>> \
-        # yamllint disable-line rule:line-length
         'echo "export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" >> "$BASH_ENV" && echo "export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" >> "$BASH_ENV" &&echo "export AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}" >> "$BASH_ENV"'

--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -28,6 +28,9 @@ parameters:
   aws-secret-access-key-env-var:
     default: AWS_SECRET_ACCESS_KEY
     type: env_var_name
+  aws-region:
+    default: AWS_REGION
+    type: env_var_name
   executor:
     default: python
     description: |
@@ -51,7 +54,7 @@ steps:
             config: <<parameters.config>>
   - aws-cli/setup:
       aws-access-key-id: << parameters.aws-access-key-id-env-var >>
-      aws-region: AWS_REGION
+      aws-region: << parameters.aws-region >>
       aws-secret-access-key: << parameters.aws-secret-access-key-env-var >>
 
   - terraform-install:


### PR DESCRIPTION
The comment in the fleece-run-to-env.yml file appears to be being parsed by Circle now which is causing an execution error when running the fleece command. This removes the comment in favor of a `.yamllint` config file.