### PR TITLE
configure poetry to always use in project venvs

### DIFF
--- a/src/commands/poetry-install.yml
+++ b/src/commands/poetry-install.yml
@@ -40,6 +40,7 @@ steps:
       description: Install dependencies from << parameters.path >>
       working_directory: << parameters.path >>
       command: |
+        poetry config --local virtualenvs.in-project true
         poetry install \
         <<# parameters.no-dev >> --no-dev<</ parameters.no-dev >> \
         <<# parameters.no-root >> --no-root<</ parameters.no-root >> \

--- a/src/commands/poetry-install.yml
+++ b/src/commands/poetry-install.yml
@@ -35,12 +35,22 @@ parameters:
     description: Do not ask any interactive question
     type: boolean
     default: true
+  virtualenv-in-project:
+    description: Ensures poetry's local config creates the virtualenv in the project directory
+    type: boolean
+    default: true
 steps:
+  - run:
+      description: Set virtualenv to exist in project root
+      when:
+        condition: << parameters.virtualenv-in-project >>
+      working_directory: << parameters.path >>
+      command: |
+        poetry config --local virtualenvs.in-project true
   - run:
       description: Install dependencies from << parameters.path >>
       working_directory: << parameters.path >>
       command: |
-        poetry config --local virtualenvs.in-project true
         poetry install \
         <<# parameters.no-dev >> --no-dev<</ parameters.no-dev >> \
         <<# parameters.no-root >> --no-root<</ parameters.no-root >> \

--- a/src/jobs/poetry-install.yml
+++ b/src/jobs/poetry-install.yml
@@ -71,6 +71,10 @@ parameters:
     default: src/
     description: >
       The relative difference between workspace-root and the working directory
+  virtualenv-in-project:
+    description: Ensures poetry's local config creates the virtualenv in the project directory
+    type: boolean
+    default: true
   restore-cache:
     description: |
       Save the venv to cache
@@ -107,6 +111,7 @@ steps:
       extras: << parameters.extras >>
       verbose: << parameters.verbose >>
       arbitrary-flags: << parameters.arbitrary-flags >>
+      virtualenv-in-project: << parameters.virtualenv-in-project >>
   - when:
       condition: <<parameters.save-cache>>
       steps:


### PR DESCRIPTION
The poetry-install step expects that the virtualenv will be created in
.venv, but not all projects may have created a poetry.toml file to put
it there. This calls `poetry config --local virtualenvs.in-project true`
which enforces the setting before install is called.