### PR TITLE
API ID stage parameter should use env var value

### DIFF
--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -121,7 +121,7 @@ steps:
       condition: <<parameters.update-gatekeeper-policy>>
       steps:
         - get-api-id:
-            stage: <<parameters.stage>>
+            stage: "${STAGE}"
             path: <<parameters.path>>
         - get-rax-token
         - update-gatekeeper-policy:


### PR DESCRIPTION
`<< parameters.stage >>` does not have the effective stage name as a value when deploying to a user-named stage.

Not entirely sure this is the correct notation to pass the env var's value as a parameter into the command.