### PR TITLE
Add TF_VAR_version_tag to replace TF_VAR_version

### DIFF
--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -99,6 +99,9 @@ steps:
       environment-variable: TF_VAR_version
       value: '${CIRCLE_SHA1:-"0.0.0"}'
   - export-env-var:
+      environment-variable: TF_VAR_version_tag  # Newer versiona of Terraform have reserved "version" for internal use.
+      value: '${CIRCLE_SHA1:-"0.0.0"}'
+  - export-env-var:
       environment-variable: TERRAFORM_BUCKET
       value: "${AWS_ACCOUNT_ID}-terraform"
   - export-env-var:


### PR DESCRIPTION
Terraform 0.12 reserves the use of "version" as a variable for internal
purposes only.
