### PR TITLE
This PR updates ubuntu image from 16.04 to 20.04

### DIFF
--- a/src/executors/machine-ubuntu.yml
+++ b/src/executors/machine-ubuntu.yml
@@ -1,7 +1,7 @@
 parameters:
   tag:
     type: string
-    default: 202101-01
+    default: 202201-02
   working_directory:
     type: string
     default: /home/circleci/src

--- a/src/jobs/sam-build.yml
+++ b/src/jobs/sam-build.yml
@@ -57,6 +57,7 @@ steps:
       steps:
         - attach_workspace:
             at: <<parameters.workspace-root>>
+  - run: pyenv install << parameters.pyenv-version >>
   - run: pyenv local << parameters.pyenv-version >>
   - run: pip install aws-sam-cli
   - sam-build:

--- a/src/jobs/sam-build.yml
+++ b/src/jobs/sam-build.yml
@@ -9,7 +9,7 @@ parameters:
     default: "3.6.11"
   executor:
     type: executor
-    default: machine-ubuntu-1604
+    default: machine-ubuntu
   attach-workspace:
     default: true
     description: >


### PR DESCRIPTION
Circle CI is deprecating ubuntu 16.04 and 14.04 images. 
The supported image is Ubuntu 20.04. 
This PR takes care of updating to latest ubuntu image.