### PR TITLE
python38 executors

### DIFF
--- a/src/executors/python38-with-dynamo.yml
+++ b/src/executors/python38-with-dynamo.yml
@@ -1,0 +1,11 @@
+parameters:
+  docker_tag:
+    default: "3.8.12"
+    type: string
+  working_directory:
+    default: /home/circleci/src
+    type: string
+working_directory: << parameters.working_directory >>
+docker:
+  - image: cimg/python:<< parameters.docker_tag >>
+  - image: amazon/dynamodb-local

--- a/src/executors/python38.yml
+++ b/src/executors/python38.yml
@@ -1,0 +1,10 @@
+parameters:
+  docker_tag:
+    default: "3.8.12"
+    type: string
+  working_directory:
+    default: /home/circleci/src
+    type: string
+working_directory: << parameters.working_directory >>
+docker:
+  - image: cimg/python:<< parameters.docker_tag >>

--- a/src/jobs/sam-build.yml
+++ b/src/jobs/sam-build.yml
@@ -6,7 +6,7 @@ parameters:
   pyenv-version:
     description: Version of python to use with pyenv
     type: string
-    default: "3.6.11"
+    default: "3.8.12"
   executor:
     type: executor
     default: machine-ubuntu

--- a/src/jobs/sam-build.yml
+++ b/src/jobs/sam-build.yml
@@ -6,7 +6,7 @@ parameters:
   pyenv-version:
     description: Version of python to use with pyenv
     type: string
-    default: "3.8.12"
+    default: "3.6.11"
   executor:
     type: executor
     default: machine-ubuntu


### PR DESCRIPTION
Since Python 3.6 End-Of-Life (EOL) reached on December 23rd, 2021, Lambda will no longer apply security patches and other updates to the Python 3.6 runtime used by Lambda functions, and functions using Python 3.6 will no longer be eligible for technical support from July 18th, 2022 onwards. 

Hence, we're upgrading our existing Python 3.6 functions to Python 3.8 for now.