### PR TITLE
Fix pyenv path issue when building Lambda packages via Terraform

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ workflows:
       - orb-tools/lint
       # Linting for BASH commands
       - orb-tools/shellcheck:
-          exclude: "SC1009,SC1073"
+          exclude: "SC1009,SC1073,SC2016"
       # Pack the orb into a single file and validate the result.
       - orb-tools/pack
       # release dev version of orb, for testing & possible publishing.

--- a/src/commands/update-default-path.yml
+++ b/src/commands/update-default-path.yml
@@ -1,0 +1,9 @@
+description: "Update default path with custom bin location"
+parameters:
+  custom-bin-location:
+    type: string
+    default: /home/circleci/.local/bin
+steps:
+  - run:
+      name: Exporting PATH the proper way
+      command: echo 'export PATH=${PATH}:<< parameters.custom-bin-location >>' >> "$BASH_ENV"

--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -71,9 +71,7 @@ steps:
 
   - terraform-install:
       terraform-version: <<parameters.terraform-version>>
-  - export-env-var:
-      environment-variable: PATH
-      value: "${PATH}:/home/circleci/.local/bin"
+  - update-default-path
 
   - when:
       condition: <<parameters.use-sops>>


### PR DESCRIPTION
Ran into an interesting issue as I was upgrading our rsspca version in the platform-services-core project. Since it's now using a more recent version of the ubuntu machine, the following error occured:

```
Error: failed to execute "python3": /opt/circleci/.pyenv/libexec/pyenv-exec: line 24: pyenv-version-name: command not found
```

Found this as a solution after googling:

https://github.com/CircleCI-Public/gcp-cli-orb/issues/22

After changing the deploy job to use single quotes when exporting the PATH, the job was green again.