### PR TITLE
Artifact-based deployments

### DIFF
--- a/src/commands/download-artifact.yml
+++ b/src/commands/download-artifact.yml
@@ -1,0 +1,18 @@
+description: Download an artifact from a previous build job
+parameters:
+  path:
+    type: string
+  build-job-name:
+    type: string
+    description: |
+      This must be set to the name of the job that built the artifact we would
+      like to use in subsequent steps.
+steps:
+  - run:
+      name: Query CircleCI API for artifacts from the current build
+      command: |
+        BUILD_JOB_NUMBER=`curl -H "Circle-Token: ${CIRCLE_TOKEN}" https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}/job | jq '.items[] | select( .name == "<<parameters.build-job-name>>" ) | .job_number '`
+        echo "Build job number: ${BUILD_JOB_NUMBER}"
+        ARTIFACT_URL=`curl -H "Circle-Token: ${CIRCLE_TOKEN}" https://circleci.com/api/v2/project/gh/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${BUILD_JOB_NUMBER}/artifacts | jq -r ' .items[0].url '`
+        echo "Downloading artifact from URL: ${ARTIFACT_URL}"
+        cd <<parameters.path>>/ && wget --header="Circle-Token: ${CIRCLE_TOKEN}" ${ARTIFACT_URL}

--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -52,11 +52,47 @@ parameters:
   user-deploy:
     type: boolean
     default: false
+  attach-workspace:
+    default: true
+    description: |
+      Boolean for whether or not to attach to an existing workspace. Default is
+      true.
+
+      If you have too many deploy jobs gated by a manual approval step, you
+      might end up with very slow deploy jobs due to CircleCI attaching every
+      single pre-existing workspace within the workflow prior to the approval
+      step.
+    type: boolean
+  use-artifacts:
+    type: boolean
+    default: false
+    description: |
+      You can instruct the deploy job to use an existing artifact from a
+      previous build job instead of creating a new one from scratch using
+      Terraform's Lambda module.
+
+      Please note that the CIRCLE_TOKEN environment variable must be set for
+      this to work properly.
+  build-job-name:
+    type: string
+    default: build-job-name
+    description: |
+      This must be set to the name of the job that built the artifact we would
+      like to deploy in this job.
 executor: << parameters.executor >>
 steps:
   - checkout
-  - attach_workspace:
-      at: /home/circleci
+  - when:
+      condition: <<parameters.attach-workspace>>
+      steps:
+        - attach_workspace:
+            at: /home/circleci
+  - when:
+      condition: <<parameters.use-artifacts>>
+      steps:
+        - download-artifact:
+            path: <<parameters.path>>
+            build-job-name: <<parameters.build-job-name>>
   - when:
       condition: <<parameters.fleece-run-to-env>>
       steps:

--- a/src/jobs/sam-build.yml
+++ b/src/jobs/sam-build.yml
@@ -44,6 +44,18 @@ parameters:
     default: src/
     description: >
       The relative difference between workspace-root and the working directory
+  template-resource-name:
+    type: string
+    default: LambdaFunction
+    description: >
+      Tha logical name under which the function to be built can be found.
+      It is used to construct the path to the SAM build artifacts in order
+      to generate the Lambda ZIP file.
+  store-artifact:
+    default: false
+    description: |
+      Store the build file as a job artifact?
+    type: boolean
 # In order to use "sam build --use-container" we need to use
 # a VM executor with docker installed locally.
 executor: <<parameters.executor>>
@@ -62,6 +74,16 @@ steps:
   - run: pip install aws-sam-cli
   - sam-build:
       path: << parameters.path >>
+  - when:
+      condition: <<parameters.store-artifact>>
+      steps:
+        - run:
+            name: Create ZIP file for Lambda function
+            command: zip -r <<parameters.workspace-root>><<parameters.template-resource-name>>.zip .
+            working_directory: <<parameters.workspace-root>><<parameters.workspace-root-to-working-directory>><<parameters.path>>/.aws-sam/build/<<parameters.template-resource-name>>/
+        - store_artifacts:
+            path: <<parameters.workspace-root>><<parameters.template-resource-name>>.zip
+            destination: <<parameters.template-resource-name>>.zip
   - when:
       condition: <<parameters.persist-to-workspace>>
       steps:


### PR DESCRIPTION
I have noticed that some of our more complex CircleCI workflows had been suboptimal for various reasons.

One of them was that in some cases we ended up building Lambda packages twice: once with the SAM build step, then during deploy if the Terraform Lambda module was used with certain parameters.

The other issue was attaching the workspace to deploy jobs that were behind a manual hold step, because at that point every single job prior to the approval step became a parent of the subsequent deploy jobs, which meant that every single workspace was attached by CircleCI and that operation can be quite slow.