### PR TITLE
Allow --no-ansi option to be used during Poetry install

### DIFF
--- a/src/commands/poetry-install.yml
+++ b/src/commands/poetry-install.yml
@@ -6,6 +6,10 @@ parameters:
     type: string
 
   # Optional
+  no-ansi:
+    description: Disable ANSI output (might be required in certain edge cases with Poetry & CircleCI)
+    type: boolean
+    default: false
   no-dev:
     description: Do not install the development dependencies.
     type: boolean
@@ -53,6 +57,7 @@ steps:
       working_directory: << parameters.path >>
       command: |
         poetry install \
+        <<# parameters.no-ansi >> --no-ansi<</ parameters.no-ansi >> \
         <<# parameters.no-dev >> --no-dev<</ parameters.no-dev >> \
         <<# parameters.no-root >> --no-root<</ parameters.no-root >> \
         <<# parameters.dry-run >> --dry-run<</ parameters.dry-run >> \

--- a/src/jobs/poetry-install.yml
+++ b/src/jobs/poetry-install.yml
@@ -4,6 +4,10 @@ parameters:
     description: Directory containing the pyproject.toml
     type: string
     default: "."
+  no-ansi:
+    description: Disable ANSI output (might be required in certain edge cases with Poetry & CircleCI)
+    type: boolean
+    default: false
   no-dev:
     description: Do not install the development dependencies.
     type: boolean
@@ -104,6 +108,7 @@ steps:
               - v1-{{.Environment.CIRCLE_CACHE_NUMBER}}-poetry-install-cache-{{checksum "<<parameters.path>>/poetry.lock"}}
   - poetry-install:
       path: << parameters.path >>
+      no-ansi: << parameters.no-ansi >>
       no-dev: << parameters.no-dev >>
       no-root: << parameters.no-root >>
       dry-run: << parameters.dry-run >>


### PR DESCRIPTION
As I wanted to use the most recent version of CircleCI's official Python 3.8.x executor in order to utilize the latest version of Poetry, I ran into the following issue: https://github.com/python-poetry/poetry/issues/7184

The workaround suggested in that ticket is to pass `--no-ansi` to `poetry install`.