### PR TITLE
Python310 executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ workflows:
       - orb-tools/lint
       # Linting for BASH commands
       - orb-tools/shellcheck:
-          exclude: "SC1009,SC1073,SC2016"
+          exclude: "SC1009,SC1073,SC2016,SC2296"
       # Pack the orb into a single file and validate the result.
       - orb-tools/pack
       # release dev version of orb, for testing & possible publishing.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
 # rsspca
 Rackspace Solutions and Services Public Circle Automation
 
+## How to publish dev:alpha version orb?
+
+* Create a new personal API token here:
+https://circleci.com/account/api
+* Run `circleci setup` command in terminal.
+* Enter the Api token when asked for.
+* From the root execute publish-alpha.sh.
+
+
 

--- a/src/executors/python310-with-dynamo.yml
+++ b/src/executors/python310-with-dynamo.yml
@@ -1,0 +1,11 @@
+parameters:
+  docker_tag:
+    default: "3.10.14"
+    type: string
+  working_directory:
+    default: /home/circleci/src
+    type: string
+working_directory: << parameters.working_directory >>
+docker:
+  - image: cimg/python:<< parameters.docker_tag >>
+  - image: amazon/dynamodb-local

--- a/src/executors/python310.yml
+++ b/src/executors/python310.yml
@@ -1,0 +1,10 @@
+parameters:
+  docker_tag:
+    default: "3.10.14"
+    type: string
+  working_directory:
+    default: /home/circleci/src
+    type: string
+working_directory: << parameters.working_directory >>
+docker:
+  - image: cimg/python:<< parameters.docker_tag >>


### PR DESCRIPTION
Since Python 3.8 End-Of-Life (EOL) reached on October 14th, 2024, Lambda will no longer apply security patches and other updates to the Python 3.8 runtime used by Lambda functions, and functions using Python 3.8 will no longer be eligible for technical support from Feb 28th, 2025 onwards.

Hence, we're upgrading our existing Python 3.8 functions to Python 3.10 for now.