### PR TITLE
fingerprint for a new ssh deploy key which has read-write permission …

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ workflows:
           publish-version-tag: true
           fail-if-semver-not-indicated: false
           bot-user: racker-autobot
-          ssh-fingerprints: "5c:13:24:90:7e:0f:c9:d5:f7:16:55:3e:86:d9:5b:64"
+          ssh-fingerprints: "SHA256:0Qmlu2nMYT17t2Gj+0SyCjYP1qYVbz6pZc0jwlILOyc"
           requires:
             - integration-tests-for-your-orb
           filters:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ https://circleci.com/account/api
 * From the root execute publish-alpha.sh.
 
 ## How to release an orb?
-Add a commit subject containing the text `[semver:patch|minor|major|skip]` in the first line while merging to master.
+In the merge commit subject title bar add the text `[semver:patch|minor|major|skip]` while merging to master.
+
 e.g. Merge pull request #33 from rackerlabs/python38-executor [semver:patch]
 
 


### PR DESCRIPTION
Added a new github deploy key(https://circleci.com/docs/github-integration/#create-additional-github-ssh-keys) which has read-write permission to push a git tag back to the project's repository