### PR TITLE
Orbtools updated 10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
     # - your-orb/your-orb-command
 
 workflows:
-  lint_pack-validate_publish-dev:
+  test-pack:
     unless: << pipeline.parameters.run-integration-tests >>
     jobs:
       # This `lint-pack_validate_publish-dev` workflow will run on any commit
@@ -63,7 +63,7 @@ workflows:
   # when the run-integration-tests pipeline parameter is set to true.
   # It is meant to be triggered by the "trigger-integration-tests-workflow"
   # job, and run tests on <your orb>@dev:${CIRCLE_SHA1:0:7}.
-  integration-tests_prod-release:
+  integration-test_deploy:
     when: << pipeline.parameters.run-integration-tests >>
     jobs:
       # your integration test jobs go here: essentially, run all your orb's

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  orb-tools: circleci/orb-tools@9.1
+  orb-tools: circleci/orb-tools@10
   rsspca: rackerlabs/rsspca@<<pipeline.parameters.dev-orb-version>>
 
 orb_prep_jobs: &orb_prep_jobs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,9 +30,6 @@ workflows:
       # This `lint-pack_validate_publish-dev` workflow will run on any commit
       # Lint your YAML
       - orb-tools/lint
-      # Linting for BASH commands
-      - orb-tools/shellcheck:
-          exclude: "SC1009,SC1073,SC2016,SC2296"
       # Pack the orb into a single file and validate the result.
       - orb-tools/pack
       # release dev version of orb, for testing & possible publishing.
@@ -45,7 +42,6 @@ workflows:
           orb-name: rackerlabs/rsspca
           requires:
             - orb-tools/lint
-            - orb-tools/shellcheck
             - orb-tools/pack
 
       # trigger an integration workflow to test the

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,13 +4,6 @@ orbs:
   orb-tools: circleci/orb-tools@10
   rsspca: rackerlabs/rsspca@<<pipeline.parameters.dev-orb-version>>
 
-orb_prep_jobs: &orb_prep_jobs
-  [
-    orb-tools/lint,
-    orb-tools/shellcheck,
-    orb-tools/pack
-  ]
-
 # Pipeline parameters
 parameters:
   # These pipeline parameters are required by the "trigger-integration-tests-workflow"
@@ -50,7 +43,10 @@ workflows:
       # if using Contexts, add your context below
       - orb-tools/publish-dev:
           orb-name: rackerlabs/rsspca
-          requires: *orb_prep_jobs
+          requires:
+            - orb-tools/lint
+            - orb-tools/shellcheck
+            - orb-tools/pack
 
       # trigger an integration workflow to test the
       # dev:${CIRCLE_SHA1:0:7} version of your orb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 orbs:
   orb-tools: circleci/orb-tools@10
   rsspca: rackerlabs/rsspca@<<pipeline.parameters.dev-orb-version>>
+  rsspca-exec: rackerlabs/rsspca@0.14.1
 
 # Pipeline parameters
 parameters:
@@ -17,7 +18,7 @@ parameters:
 
 jobs:
   integration-tests-for-your-orb:
-    executor: orb-tools/ubuntu
+    executor: rsspca-exec/machine-ubuntu
     steps:
       - checkout
     # Test your orb e.g.


### PR DESCRIPTION
Updated the orbtools to v10.0.0 as with existing v9.1.0 had issues during push git tags. The git tag version obtained from the PUBLISH_MESSAGE was not in the expected format as the CircleCI CLI was response had more lines/info to it. We had no control over this workflow as it was imported from orbtools(v9.1.0).

e.g `fatal: 'vOnce an orb is created it cannot be deleted. Orbs are semver compliant, and each published version is immutable. Publicly released orbs are potential dependencies for other projects. Therefore, allowing orb deletion would make users susceptible to unexpected loss of functionality. 0.18.1' is not a valid tag name` 

![image](https://github.com/rackerlabs/rsspca/assets/91481068/0756c585-7f07-47c8-8f78-1be5b6687428)

To overcome this bug, we had to update orbtools to version 10 and the necessary workflow updates were made to support this new version.