### PR TITLE
new python312 executor added

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ workflows:
           publish-version-tag: true
           fail-if-semver-not-indicated: false
           bot-user: racker-autobot
-          ssh-fingerprints: "SHA256:0Qmlu2nMYT17t2Gj+0SyCjYP1qYVbz6pZc0jwlILOyc"
+          ssh-fingerprints: "SHA256:X5MWMrTYIeeo4385NgkU/K6jJj8OA0GgfgJCgT6bFRA"
           requires:
             - integration-tests-for-your-orb
           filters:

--- a/src/executors/python312-with-dynamo.yml
+++ b/src/executors/python312-with-dynamo.yml
@@ -1,0 +1,11 @@
+parameters:
+  docker_tag:
+    default: "3.12.9"
+    type: string
+  working_directory:
+    default: /home/circleci/src
+    type: string
+working_directory: << parameters.working_directory >>
+docker:
+  - image: cimg/python:<< parameters.docker_tag >>
+  - image: amazon/dynamodb-local

--- a/src/executors/python312.yml
+++ b/src/executors/python312.yml
@@ -1,0 +1,10 @@
+parameters:
+  docker_tag:
+    default: "3.12.9"
+    type: string
+  working_directory:
+    default: /home/circleci/src
+    type: string
+working_directory: << parameters.working_directory >>
+docker:
+  - image: cimg/python:<< parameters.docker_tag >>


### PR DESCRIPTION
AWS Lambda Python 3.10 runtime is approaching end-of-life (EOL), with deprecation scheduled for October 31, 2026, after which creation and updates for functions using this runtime will be restricted.

This activity aims to identify all Lambda functions running on Python 3.10 and upgrade them to a supported runtime (Python 3.11 or later) to ensure continued security updates, supportability, and compliance.

This repository contains the CircleCI Python executor code used by other repositories to build installer dependencies. As part of this change, we need to publish a new CircleCI orb to ensure downstream projects can adopt the updated Python version.